### PR TITLE
Porting for kernel 4.14.19

### DIFF
--- a/drivers/infiniband/hw/ntrdma/ntrdma_cq.c
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_cq.c
@@ -96,6 +96,8 @@ void ntrdma_cq_del(struct ntrdma_cq *cq)
 	}
 	spin_unlock_bh(&cq->arm_lock);
 
+	tasklet_kill(&cq->cue_work);
+
 	mutex_lock(&dev->res_lock);
 	{
 		list_del(&cq->obj.dev_entry);

--- a/drivers/infiniband/hw/ntrdma/ntrdma_ib.c
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_ib.c
@@ -102,7 +102,8 @@ static int ntrdma_query_gid(struct ib_device *ibdev,
 
 /* not implemented / not required? */
 static struct ib_ah *ntrdma_create_ah(struct ib_pd *ibpd,
-				      struct ib_ah_attr *ibattr)
+				      struct ib_ah_attr *ibattr,
+				      struct ib_udata *udata)
 {
 	pr_debug("not implemented, returning %d\n", -ENOSYS);
 	return ERR_PTR(-ENOSYS);

--- a/drivers/infiniband/hw/ntrdma/ntrdma_ib.c
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_ib.c
@@ -102,7 +102,7 @@ static int ntrdma_query_gid(struct ib_device *ibdev,
 
 /* not implemented / not required? */
 static struct ib_ah *ntrdma_create_ah(struct ib_pd *ibpd,
-				      struct ib_ah_attr *ibattr,
+				      struct rdma_ah_attr *ah_attr,
 				      struct ib_udata *udata)
 {
 	pr_debug("not implemented, returning %d\n", -ENOSYS);
@@ -952,7 +952,7 @@ int ntrdma_dev_ib_init(struct ntrdma_dev *dev)
 	/* TODO: maybe this should be the number of virtual doorbells */
 	ibdev->num_comp_vectors		= 1;
 
-	ibdev->dma_device = ntc_map_dev(dev->ntc);
+	ibdev->dev.parent = ntc_map_dev(dev->ntc);
 
 	ibdev->uverbs_abi_ver		= 1;
 	ibdev->phys_port_cnt		= 1;

--- a/drivers/infiniband/hw/ntrdma/ntrdma_qp.c
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_qp.c
@@ -845,6 +845,8 @@ void ntrdma_rqp_del(struct ntrdma_rqp *rqp)
 	rqp->state = NTRDMA_QPS_RESET;
 	ntrdma_dev_vbell_del(dev, &rqp->send_vbell, rqp->send_vbell_idx);
 
+	tasklet_kill(&rqp->send_work);
+
 	ntrdma_rres_del(&rqp->rres);
 	ntrdma_debugfs_rqp_del(rqp);
 }

--- a/drivers/infiniband/hw/ntrdma/ntrdma_vbell.c
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_vbell.c
@@ -107,7 +107,7 @@ u32 ntrdma_dev_vbell_next(struct ntrdma_dev *dev)
 	{
 		idx = dev->vbell_next;
 
-		if (dev->vbell_count < ++dev->vbell_next)
+		if (dev->vbell_count <= ++dev->vbell_next)
 			dev->vbell_next = dev->vbell_start;
 	}
 	spin_unlock_bh(&dev->vbell_next_lock);
@@ -233,6 +233,9 @@ static void ntrdma_dev_vbell_work(struct ntrdma_dev *dev)
 		}
 	}
 	spin_unlock_bh(&dev->vbell_self_lock);
+
+	if (ntc_clear_signal(dev->ntc))
+		tasklet_schedule(&dev->vbell_work);
 }
 
 static void ntrdma_dev_vbell_work_cb(unsigned long ptrhld)

--- a/drivers/ntc/ntc_tcp.c
+++ b/drivers/ntc/ntc_tcp.c
@@ -38,6 +38,7 @@
 #include <linux/inet.h>
 #include <linux/kthread.h>
 #include <linux/sched.h>
+#include <linux/sched/signal.h>
 #include <net/net_namespace.h>
 #include <linux/tcp.h>
 

--- a/makefile
+++ b/makefile
@@ -1,5 +1,6 @@
-
+ifndef KSRC
 KSRC		= /lib/modules/$(shell uname -r)/build
+endif
 V		= 0
 
 # Build the ntrdma kernel module


### PR DESCRIPTION
1. Probably https://github.com/ntrdma/ntrdma-ext/pull/2/commits/44cb7cf5e4f9efc1d1629fb9c027b38ba115ca72 should be cherry-picked commits from ntrdma/ntrdma into ntrdma/ntrdma-ext
2. The https://github.com/ntrdma/ntrdma-ext/pull/2/commits/03132ba00b418c6283c3e9a1a96ff0cc729757f8 is for updated kernel... We can have it in a separate branch or merged to master after review or maybe handle as ifdefs in the code...

@allenbh please advise