### PR TITLE
simplified negotiation phases:

### DIFF
--- a/drivers/infiniband/hw/ntrdma/ntrdma.h
+++ b/drivers/infiniband/hw/ntrdma/ntrdma.h
@@ -91,6 +91,9 @@ int ntrdma_dev_init(struct ntrdma_dev *dev,
 		      struct ntc_dev *ntc);
 void ntrdma_dev_deinit(struct ntrdma_dev *dev);
 
+int ntrdma_dev_hello_init(struct ntrdma_dev *dev, struct ntc_dev *ntc);
+void ntrdma_dev_hello_deinit(struct ntrdma_dev *dev);
+
 int ntrdma_dev_ib_init(struct ntrdma_dev *dev);
 void ntrdma_dev_ib_deinit(struct ntrdma_dev *dev);
 
@@ -98,9 +101,7 @@ int ntrdma_dev_eth_init(struct ntrdma_dev *dev,
 			  u32 vbell_idx, u32 rx_cap);
 void ntrdma_dev_eth_deinit(struct ntrdma_dev *dev);
 
-ssize_t ntrdma_dev_hello(struct ntrdma_dev *dev, int phase,
-			 void *in_buf, size_t in_size,
-			 void *out_buf, size_t out_size);
+int ntrdma_dev_hello(struct ntrdma_dev *dev, int phase);
 
 int ntrdma_dev_res_init(struct ntrdma_dev *dev);
 void ntrdma_dev_res_deinit(struct ntrdma_dev *dev);

--- a/drivers/infiniband/hw/ntrdma/ntrdma_dev.h
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_dev.h
@@ -149,6 +149,12 @@ struct ntrdma_dev {
 	u64				peer_cmd_recv_prod_addr;
 	u32				peer_cmd_recv_vbell_idx;
 
+	/* hello buffers */
+	u8 *hello_local_buf;
+	int hello_local_buf_size;
+	u8 *hello_peer_buf;
+	int hello_peer_buf_size;
+
 	/* rdma resource synchronization state */
 
 	int				res_enable;

--- a/drivers/infiniband/hw/ntrdma/ntrdma_eth.c
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_eth.c
@@ -234,16 +234,21 @@ void ntrdma_dev_eth_deinit(struct ntrdma_dev *dev)
 	free_netdev(net);
 }
 
-void ntrdma_dev_eth_hello_info(struct ntrdma_dev *dev,
+int ntrdma_dev_eth_hello_info(struct ntrdma_dev *dev,
 			       struct ntrdma_eth_hello_info *info)
 {
 	struct ntrdma_eth *eth = dev->eth;
 
 	info->rx_cap = eth->rx_cap;
 	info->rx_idx = eth->rx_cmpl;
+	if (!eth->rx_cqe_buf_addr || !eth->rx_cons_buf_addr)
+		return -EINVAL;
+
 	info->rx_buf_addr = eth->rx_cqe_buf_addr;
 	info->rx_idx_addr = eth->rx_cons_buf_addr;
 	info->vbell_idx = eth->vbell_idx;
+
+	return 0;
 }
 
 int ntrdma_dev_eth_hello_prep(struct ntrdma_dev *dev,

--- a/drivers/infiniband/hw/ntrdma/ntrdma_hello.h
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_hello.h
@@ -70,7 +70,7 @@ struct ntrdma_eth_hello_prep {
 	u64				tx_idx_addr;
 };
 
-void ntrdma_dev_eth_hello_info(struct ntrdma_dev *dev,
+int ntrdma_dev_eth_hello_info(struct ntrdma_dev *dev,
 			       struct ntrdma_eth_hello_info *info);
 int ntrdma_dev_eth_hello_prep(struct ntrdma_dev *dev,
 			      struct ntrdma_eth_hello_info *peer_info,

--- a/drivers/ntc/ntc.c
+++ b/drivers/ntc/ntc.c
@@ -142,7 +142,7 @@ void ntc_clear_ctx(struct ntc_dev *ntc)
 }
 EXPORT_SYMBOL(ntc_clear_ctx);
 
-ssize_t ntc_ctx_hello(struct ntc_dev *ntc, int phase,
+int ntc_ctx_hello(struct ntc_dev *ntc, int phase,
 		      void *in_buf, size_t in_size,
 		      void *out_buf, size_t out_size)
 {

--- a/include/linux/ntc.h
+++ b/include/linux/ntc.h
@@ -76,7 +76,7 @@ static inline int ntc_driver_ops_is_valid(const struct ntc_driver_ops *ops)
  * @clear_signal:	See ntc_ctx_clear_signal().
  */
 struct ntc_ctx_ops {
-	ssize_t (*hello)(void *ctx, int phase,
+	int (*hello)(void *ctx, int phase,
 			 void *in_buf, size_t in_size,
 			 void *out_buf, size_t out_size);
 	void (*enable)(void *ctx);
@@ -141,6 +141,8 @@ struct ntc_dev_ops {
 			  void (*cb)(void *cb_ctx), void *cb_ctx, int vec);
 	int (*clear_signal)(struct ntc_dev *ntc, int vec);
 	int (*max_peer_irqs)(struct ntc_dev *ntc);
+	void *(*local_hello_buf)(struct ntc_dev *ntc, int *size);
+	void *(*peer_hello_buf)(struct ntc_dev *ntc, int *size);
 };
 
 static inline int ntc_dev_ops_is_valid(const struct ntc_dev_ops *ops)
@@ -266,6 +268,16 @@ static inline int ntc_max_peer_irqs(struct ntc_dev *ntc)
 			return 1;
 
 	return ntc->dev_ops->max_peer_irqs(ntc);
+}
+
+static inline void *ntc_local_hello_buf(struct ntc_dev *ntc, int *size)
+{
+	return ntc->dev_ops->local_hello_buf(ntc, size);
+}
+
+static inline void *ntc_peer_hello_buf(struct ntc_dev *ntc, int *size)
+{
+	return ntc->dev_ops->peer_hello_buf(ntc, size);
 }
 
 static inline int ntc_door_bell_arbitrator(struct ntc_dev *ntc)
@@ -409,7 +421,7 @@ static inline void *ntc_get_ctx(struct ntc_dev *ntc)
  *
  * Return: Input buffer size for phase after next, zero, or an error number.
  */
-ssize_t ntc_ctx_hello(struct ntc_dev *ntc, int phase,
+int ntc_ctx_hello(struct ntc_dev *ntc, int phase,
 		      void *in_buf, size_t in_size,
 		      void *out_buf, size_t out_size);
 


### PR DESCRIPTION
 - state machine
 - hello buffers were moved to mw1
 - ntrdma is managing the hello buffers instead of ntc_ntb_msi (i.e double buffering etc)

Signed-off-by: Leonid Ravich <Leonid.Ravich@emc.com>