### PR TITLE
improving the defensiveness of the negotiation code

### DIFF
--- a/drivers/infiniband/hw/ntrdma/ntrdma_dev.h
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_dev.h
@@ -194,6 +194,9 @@ struct ntrdma_dev {
 #define ntrdma_dbg(dev, args...) \
 	dev_dbg(&(dev)->ntc->dev, ## args)
 
+#define ntrdma_err(dev, args...) \
+	dev_err(&(dev)->ntc->dev, ## args)
+
 #define ntrdma_vdbg(dev, args...) \
 	dev_vdbg(&(dev)->ntc->dev, ## args)
 

--- a/drivers/infiniband/hw/ntrdma/ntrdma_hello.h
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_hello.h
@@ -35,6 +35,8 @@
 
 #include "ntrdma.h"
 
+#define MAX_VBELL_COUNT 1024
+
 struct ntrdma_cmd_hello_info {
 	u64 send_rsp_buf_addr;
 	u64 send_cons_addr;


### PR DESCRIPTION
sanity on the values/addresses that are recieved from peer etc
- adding some debug error prints and ntrdma_err
- adding a wrapper function to the ntc_ctx_hello

Signed-off-by: Leonid Ravich <Leonid.Ravich@emc.com>