### PR TITLE
Linux 5.2.x to upstream

### DIFF
--- a/drivers/infiniband/hw/ntrdma/ntrdma_eth.c
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_eth.c
@@ -683,7 +683,7 @@ static netdev_tx_t ntrdma_eth_start_xmit(struct sk_buff *skb,
 
 	eth->tx_cons = ntrdma_ring_update(pos + 1, base, eth->tx_cap);
 
-	if (!skb->xmit_more) {
+	if (!netdev_xmit_more()) {
 		while (eth->tx_cmpl != eth->tx_cons) {
 			ntrdma_ring_consume(eth->tx_cons,
 					    eth->tx_cmpl,

--- a/drivers/infiniband/hw/ntrdma/ntrdma_main.c
+++ b/drivers/infiniband/hw/ntrdma/ntrdma_main.c
@@ -56,7 +56,7 @@ static int ntrdma_probe(struct ntc_driver *self,
 
 	ntc_link_disable(ntc);
 
-	dev = (void *)ib_alloc_device(sizeof(*dev));
+	dev = ib_alloc_device(ntrdma_dev, ibdev);
 	if (!dev)
 		return -ENOMEM;
 

--- a/drivers/ntc/ntc_ntb_msi.c
+++ b/drivers/ntc/ntc_ntb_msi.c
@@ -616,15 +616,6 @@ static inline void ntc_ntb_db_config(struct ntc_ntb_dev *dev)
 			return;
 		}
 
-		rc = ntb_peer_db_addr(dev->ntb,
-				(phys_addr_t *)&peer_irq_addr_base,
-				&size);
-		if ((rc < 0) || (size != sizeof(u32)) ||
-				!IS_ALIGNED(peer_irq_addr_base, INTEL_ALIGN)) {
-			dev_err(&dev->ntc.dev, "Peer DB addr invalid\n");
-			return;
-		}
-
 		db_bits = ntb_db_valid_mask(dev->ntb);
 		for (db_idx = 0; db_idx < max_irqs && db_bits; db_idx++) {
 			/*FIXME This is not generic implementation,
@@ -635,6 +626,15 @@ static inline void ntc_ntb_db_config(struct ntc_ntb_dev *dev)
 			db_bits &= db_bits - 1;
 			dev->peer_irq_num++;
 			dev->peer_irq_data[db_idx] = 1;
+		}
+
+		rc = ntb_peer_db_addr(dev->ntb,
+				(phys_addr_t *)&peer_irq_addr_base,
+				&size, NULL, db_bits);
+		if ((rc < 0) || (size != sizeof(u32)) ||
+				!IS_ALIGNED(peer_irq_addr_base, INTEL_ALIGN)) {
+			dev_err(&dev->ntc.dev, "Peer DB addr invalid\n");
+			return;
 		}
 
 		peer_db_mask = ntb_db_valid_mask(dev->ntb);

--- a/drivers/ntc/ntc_ntb_msi.c
+++ b/drivers/ntc/ntc_ntb_msi.c
@@ -617,6 +617,14 @@ static inline void ntc_ntb_db_config(struct ntc_ntb_dev *dev)
 		}
 
 		db_bits = ntb_db_valid_mask(dev->ntb);
+		rc = ntb_peer_db_addr(dev->ntb,
+				(phys_addr_t *)&peer_irq_addr_base,
+				&size, NULL, __ffs(db_bits));
+		if ((rc < 0) || (size != sizeof(u32)) ||
+				!IS_ALIGNED(peer_irq_addr_base, INTEL_ALIGN)) {
+			dev_err(&dev->ntc.dev, "Peer DB addr invalid (%d)\n", rc);
+			return;
+		}
 		for (db_idx = 0; db_idx < max_irqs && db_bits; db_idx++) {
 			/*FIXME This is not generic implementation,
 			 * Sky-lake implementation, see intel_ntb3_peer_db_set() */
@@ -626,15 +634,6 @@ static inline void ntc_ntb_db_config(struct ntc_ntb_dev *dev)
 			db_bits &= db_bits - 1;
 			dev->peer_irq_num++;
 			dev->peer_irq_data[db_idx] = 1;
-		}
-
-		rc = ntb_peer_db_addr(dev->ntb,
-				(phys_addr_t *)&peer_irq_addr_base,
-				&size, NULL, db_bits);
-		if ((rc < 0) || (size != sizeof(u32)) ||
-				!IS_ALIGNED(peer_irq_addr_base, INTEL_ALIGN)) {
-			dev_err(&dev->ntc.dev, "Peer DB addr invalid\n");
-			return;
 		}
 
 		peer_db_mask = ntb_db_valid_mask(dev->ntb);

--- a/drivers/ntc/ntc_ntb_msi.c
+++ b/drivers/ntc/ntc_ntb_msi.c
@@ -364,9 +364,9 @@ static void ntc_ntb_ping_pong(struct ntc_ntb_dev *dev)
 	dev->ping_flags = ping_flags;
 }
 
-static void ntc_ntb_ping_pong_cb(unsigned long ptrhld)
+static void ntc_ntb_ping_pong_fn(struct timer_list *t)
 {
-	struct ntc_ntb_dev *dev = ntc_ntb_of_ptrhld(ptrhld);
+	struct ntc_ntb_dev *dev = from_timer(dev, t, ping_pong);
 	unsigned long irqflags;
 
 	spin_lock_irqsave(&dev->ping_lock, irqflags);
@@ -397,9 +397,9 @@ static bool ntc_ntb_ping_poll(struct ntc_ntb_dev *dev)
 	return false;
 }
 
-static void ntc_ntb_ping_poll_cb(unsigned long ptrhld)
+static void ntc_ntb_ping_poll_fn(struct timer_list *t)
 {
-	struct ntc_ntb_dev *dev = ntc_ntb_of_ptrhld(ptrhld);
+	struct ntc_ntb_dev *dev = from_timer(dev, t, ping_poll);
 	unsigned long irqflags;
 	int poll_msg;
 
@@ -1327,13 +1327,13 @@ static int ntc_ntb_dev_init(struct ntc_ntb_dev *dev)
 	dev->poll_val = 0;
 	dev->poll_msg = NTC_NTB_LINK_QUIESCE;
 
-	setup_timer(&dev->ping_pong,
-		    ntc_ntb_ping_pong_cb,
-		    ntc_ntb_to_ptrhld(dev));
+	timer_setup(&dev->ping_pong,
+		    ntc_ntb_ping_pong_fn,
+		    0);
 
-	setup_timer(&dev->ping_poll,
-		    ntc_ntb_ping_poll_cb,
-		    ntc_ntb_to_ptrhld(dev));
+	timer_setup(&dev->ping_poll,
+		    ntc_ntb_ping_poll_fn,
+		    0);
 
 	spin_lock_init(&dev->ping_lock);
 

--- a/drivers/ntc/ntc_phys.c
+++ b/drivers/ntc/ntc_phys.c
@@ -74,11 +74,11 @@ static void ntc_phys_buf_sync_dev(struct ntc_dev *ntc, u64 addr, u64 size,
 	dma_sync_single_for_device(dev, addr, size, dir);
 }
 
-static void *ntc_phys_umem_get(struct ntc_dev *ntc, struct ib_ucontext *uctx,
+static void *ntc_phys_umem_get(struct ib_udata *udata,
 			       unsigned long uaddr, size_t size,
 			       int access, int dmasync)
 {
-	return ib_umem_get(uctx, uaddr, size, access, dmasync);
+	return ib_umem_get(udata, uaddr, size, access, dmasync);
 }
 
 static void ntc_phys_umem_put(struct ntc_dev *ntc, void *umem)

--- a/drivers/ntc/ntc_virt.c
+++ b/drivers/ntc/ntc_virt.c
@@ -52,13 +52,13 @@ static void ntc_virt_buf_unmap(struct ntc_dev *ntc, u64 addr, u64 size,
 	rmb(); /* read data in the order it is received out of the channel */
 }
 
-static void *ntc_virt_umem_get(struct ntc_dev *ntc, struct ib_ucontext *uctx,
+static void *ntc_virt_umem_get(struct ib_udata *udata,
 			       unsigned long uaddr, size_t size,
 			       int access, int dmasync)
 {
 	access |= IB_ACCESS_SOFTWARE;
 
-	return ib_umem_get(uctx, uaddr, size, access, dmasync);
+	return ib_umem_get(udata, uaddr, size, access, dmasync);
 }
 
 static void ntc_virt_umem_put(struct ntc_dev *ntc, void *umem)


### PR DESCRIPTION
Port ntrdma-ext to Linux v5.2.x
Successfully tested on kernel 5.2.14.