### PR TITLE
Fix boolean-context warning

### DIFF
--- a/include/linux/ntc_mm.h
+++ b/include/linux/ntc_mm.h
@@ -72,7 +72,7 @@ static inline int _ntc_mm_chunk_size(int size)
 	if (unlikely(clz < 2))
 		return 0;
 
-	if (size << (clz + 1))
+	if ((size << (clz + 1)) != 0)
 		return 1 << (8 * sizeof(int) - clz);
 	else
 		return 1 << (8 * sizeof(int) - clz - 1);


### PR DESCRIPTION
Get rid of the following compile error:
/home/user/projects/ntrdma-ext/include/linux/ntc_mm.h: In function ‘_ntc_mm_chunk_size’:
/home/user/projects/ntrdma-ext/include/linux/ntc_mm.h:75:11: error: ‘<<’ in boolean context, did you mean ‘<’ ?
[-Werror=int-in-bool-context]
      if (size << (clz + 1))
          ~~~~~^~~~~~~~~~~~
cc1: all warnings being treated as errors